### PR TITLE
Avoid using 'safefile'

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -41,7 +41,12 @@ func iniSave(filename string, iniFile *ini.File) error {
 	// The third argument, perm, is ignored when the file doesn't exist
 	// So we can safely set it to '0644', it won't modify the existing permissions
 	// if the file exists.
-	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, os.FileMode(0644))
+	f, err := os.OpenFile(filename, os.O_SYNC|os.O_RDWR|os.O_CREATE, os.FileMode(0644))
+	if err != nil {
+		return err
+	}
+	// Clear file content
+	err = f.Truncate(0)
 	if err != nil {
 		return err
 	}

--- a/ini.go
+++ b/ini.go
@@ -3,9 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"syscall"
 
-	"github.com/dchest/safefile"
 	"github.com/go-ini/ini"
 )
 
@@ -38,44 +36,20 @@ func iniLoadOrEmpty(filename string) (*ini.File, error) {
 	return nil, err
 }
 
-// iniSave safely writes the ini file to the named file.
+// iniSave writes the ini file to the named file.
 func iniSave(filename string, iniFile *ini.File) error {
-	mode := os.FileMode(0644)
-	uid := -1
-	gid := -1
-
-	finfo, err := os.Stat(filename)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-	} else {
-		mode = finfo.Mode()
-		uid = int(finfo.Sys().(*syscall.Stat_t).Uid)
-		gid = int(finfo.Sys().(*syscall.Stat_t).Gid)
-	}
-
-	f, err := safefile.Create(filename, mode)
+	// The third argument, perm, is ignored when the file doesn't exist
+	// So we can safely set it to '0644', it won't modify the existing permissions
+	// if the file exists.
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, os.FileMode(0644))
 	if err != nil {
 		return err
 	}
-	// Recover original ownership/permissions
-	if err := os.Chmod(f.File.Name(), mode); err != nil {
-		return err
-	}
-	if os.Geteuid() != uid || os.Getegid() != gid {
-		if err := os.Chown(f.File.Name(), uid, gid); err != nil {
-			return err
-		}
-	}
-
-	defer f.Close()
-
 	_, err = iniFile.WriteTo(f)
 	if err != nil {
 		return err
 	}
-	return f.Commit()
+	return f.Close()
 }
 
 func iniFileGet(file string, s string, key string) (string, error) {
@@ -108,7 +82,6 @@ func iniFileSet(file string, s string, key string, value interface{}) error {
 	default:
 		return fmt.Errorf("invalid key type %T", v)
 	}
-
 	return iniSave(file, iniFile)
 }
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

This PR fixes the issue described below when running `ini-file` with an unprivileged user:

---

When we have a “non-root” container run as `1001:root` and we have a file with the permissions below:

```
-rw-rw-r-- 1 root root 22338 Apr  7 15:56 default.ini
```

The user can write in the file since it belongs to the `root` group. However, running the command below will fail:

```
./ini-file set --section section --key foo --value bar default.ini
``` 

The reason is how `ini-file` perform write operations. It's using `safefile` that create a temporal file, to replace the destination file with this temporal file later. This temporal file is created with `-rw-r-r-- 1001:root` permissions, which is wrong for two reasons:

- It's not respecting the original ownership
- It's not respecting the original permissions.

We tried to fix this by running some chown/chmod operations but it's not working since "chown" operations require privilege permissions.

---

Solution: stop using `safefile` and directly write in the destination. 
