### PR TITLE
Support ignoring inline comments in values

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -12,13 +12,18 @@ func init() {
 	ini.PrettyFormat = false
 }
 
+func loadOptions() ini.LoadOptions {
+	return ini.LoadOptions{
+		// Support mysql-style "boolean" values - a key wth no value.
+		AllowBooleanKeys:    true,
+		IgnoreInlineComment: globalOpts.IgnoreInlineComments,
+	}
+}
+
 // iniLoad attempts to load the ini file.
 func iniLoad(filename string) (*ini.File, error) {
 	return ini.LoadSources(
-		ini.LoadOptions{
-			// Support mysql-style "boolean" values - a key wth no value.
-			AllowBooleanKeys: true,
-		},
+		loadOptions(),
 		filename,
 	)
 }
@@ -31,7 +36,7 @@ func iniLoadOrEmpty(filename string) (*ini.File, error) {
 		return f, nil
 	}
 	if os.IsNotExist(err) {
-		return ini.Empty(), nil
+		return ini.Empty(loadOptions()), nil
 	}
 	return nil, err
 }

--- a/main.go
+++ b/main.go
@@ -7,12 +7,19 @@ import (
 	flags "github.com/jessevdk/go-flags"
 )
 
+// Options defines options supported by all subcommands
+type Options struct {
+	IgnoreInlineComments bool `long:"ignore-inline-comments" description:"Ignore inline comments"`
+}
+
+var globalOpts = &Options{}
+
 func main() {
 	setCmd := NewINIFileSetCmd()
 	getCmd := NewINIFileGetCmd()
 	delCmd := NewINIFileDelCmd()
 
-	parser := flags.NewParser(nil, flags.HelpFlag|flags.PassDoubleDash)
+	parser := flags.NewParser(globalOpts, flags.HelpFlag|flags.PassDoubleDash)
 
 	parser.AddCommand("set", "INI File Set", "Sets values in a INI file", setCmd)
 	parser.AddCommand("get", "INI FILE Get", "Gets values from a INI file", getCmd)


### PR DESCRIPTION
This patch enables the tool to completely ignore inline comments in values, treating them as regular data. For example:

```
[general]
mykey=my ; value
```
```
# This returns the value until the semicolon, assuming "value" is a comment
$> ini-file get --section general --key mykey myfile.ini
my
```

```
# This returns the value until the semicolon, assuming "value" is a comment
$> ini-file get --ignore-inline-comments --section general --key mykey myfile.ini
my ; value
```

The same applies to other commands:

```
# Inserts escaped version of 'my ; value' to deal with the semicolon
$> ini-file set --section general --key mykey --value 'my ; value' myfile.ini
cat myfile.ini
[general]
mykey=`my ; value`
```

```
# There is no need to escape using backticks as we are ignoring inline comments
$> ini-file  --ignore-inline-comments set --section general --key mykey --value 'my ; value' myfile.ini
cat myfile.ini
[general]
mykey=my ; value
```

This feature is useful when dealing with data that is expected to contain semicolon characters  (#7) without forcing the parser consuming the ini file to understand the backticks as escaping the value.
