### PR TITLE
Preserve array keys in modified document

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This tool allows manipulating INI files.
 
-# Baisc usage
+# Basic usage
 
 ~~~bash
 $> ini-file --help
@@ -85,3 +85,34 @@ $> cat ./my.ini
 rate=very good
 already_read
 ~~~
+
+## Working with identical keys in the file
+
+~~~bash
+$> cat > ./my.ini <<"EOF"
+[My book]
+title=A wonderful book
+author[]=Bitnami
+author[]=Contributors
+EOF
+
+# get retrieves the first mention of the key
+$> ini-file get --section "My book" --key "author[]" ./my.ini
+Bitnami
+
+# If the original file contains the key more than once, set adds the new value at the end
+$> ini-file set --section "My book" --key "author[]" --value "Other" ./my.ini
+$> cat ./my.ini
+title=A wonderful book
+author[]=Bitnami
+author[]=Contributors
+author[]=Other
+
+# del removes all keys with the given name
+$> ini-file del --section "My book" --key "author[]" ./my.ini
+$> cat ./my.ini
+title=A wonderful book
+
+~~~
+
+

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -259,6 +259,20 @@ var setTests = []iniSetTest{
 		expectedText: `\[testbool\]\nmykey=myvalue\n\s*$`,
 	},
 	{
+		name: "Set value with duplicate key",
+		initialText: `
+[testduplicate]
+mykey=value1
+mykey=value2
+		`,
+		values: []iniTestValue{
+			{
+				section: "testduplicate", key: "mykey", value: "value3",
+			},
+		},
+		expectedText: `^\[testduplicate\]\nmykey=value1\nmykey=value2\nmykey=value3\n\s*$`,
+	},
+	{
 		name: "Set multiple keys",
 		values: []iniTestValue{
 			{section: "general", key: "key1", value: "value1"},
@@ -294,6 +308,15 @@ key4=value4
 			{section: "general", key: "mykey", value: "myvalue"},
 		},
 		expectedText: `^# this is a comment\n\[general\]\n# key 1 sample\nkey1=value1\nmykey=myvalue\n\s*$`,
+	},
+	{
+		name:          "Preserve arrays",
+		createIniFile: true,
+		initialText:   "[general]\narray[]=value1\narray[]=value2",
+		values: []iniTestValue{
+			{section: "general", key: "mykey", value: "myvalue"},
+		},
+		expectedText: `^\[general\]\narray\[\]=value1\narray\[\]=value2\nmykey=myvalue\n\s*$`,
 	},
 }
 

--- a/ini.go
+++ b/ini.go
@@ -15,7 +15,9 @@ func init() {
 func loadOptions() ini.LoadOptions {
 	return ini.LoadOptions{
 		// Support mysql-style "boolean" values - a key wth no value.
-		AllowBooleanKeys:    true,
+		AllowBooleanKeys: true,
+		// Support preserving arrays in original document
+		AllowShadows:        true,
 		IgnoreInlineComment: globalOpts.IgnoreInlineComments,
 	}
 }
@@ -86,7 +88,11 @@ func iniFileSet(file string, s string, key string, value interface{}) error {
 	section := iniFile.Section(s)
 	switch v := value.(type) {
 	case string:
-		section.NewKey(key, v)
+		if section.HasKey(key) && len(section.Key(key).ValueWithShadows()) == 1 {
+			section.Key(key).SetValue(v)
+		} else {
+			section.NewKey(key, v)
+		}
 	case bool:
 		section.NewBooleanKey(key)
 	default:


### PR DESCRIPTION
This PR fixes #13. Based on feedback from the library author in https://github.com/go-ini/ini/issues/315, I added the `AllowShadows` option to the LoadOptions.

This option has two effects:
1. when loading the file, it does not remove any entries with identical keys. This applies both to normal keys (maybe not desired) and array keys (desired). I think it's OK to preserve these for non-array keys too, as it's unlikely that someone would expect the tool to deduplicate all keys in the file.
2. when setting a string key, the old key is not overwritten, but a new line with the same key is appended to the section (which is likely not desired). To address this, I modified the set function so that it modifies the existing key if it exists exactly once, which should address this issue. If the key already exists more than once, it instead adds another identical key - I think that is the most reasonable behavior for dealing with an input file that has identical keys.

As far as I can tell, this should now preserve array keys without breaking any other behavior. I also added a few test cases, let me know what you think and if I should make any changes. This fix does not address some other issues when working directly with arrays, so I added a short sections describing what it does and does not do.

Let me know what you think!