### PR TITLE
Update to Go 1.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.6' # The Go version to download (if necessary) and use.
+          go-version: '^1.18.2' # The Go version to download (if necessary) and use.
       - name: Install Build Dependencies
         run: make get-build-deps
       - name: Download required modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,11 @@
 # docker run --rm -it -v /tmp:/tmp bitnami/ini-file del -k "title" -s "My book" /tmp/my.ini
 #
 
-FROM golang:1.16-stretch as build
+FROM golang:1.18-stretch as build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git make upx \
     && rm -rf /var/lib/apt/lists/*
-
-RUN go get -u \
-        golang.org/x/lint/golint \
-        golang.org/x/tools/cmd/goimports \
-        && rm -rf $GOPATH/src/* && rm -rf $GOPATH/pkg/*
-
 
 WORKDIR /go/src/app
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean download get-build-deps vet lint get-deps test cover
+.PHONY: all build clean download get-build-deps vet lint test cover
 
 TOOL_NAME := ini-file
 
@@ -30,8 +30,7 @@ download:
 
 get-build-deps:
 	@echo "+ Downloading build dependencies"
-	@go get golang.org/x/tools/cmd/goimports
-	@go get golang.org/x/lint/golint
+	@go install honnef.co/go/tools/cmd/staticcheck@latest
 
 vet:
 	@echo "+ Vet"
@@ -39,12 +38,8 @@ vet:
 
 lint:
 	@echo "+ Linting package"
-	@golint .
+	@staticcheck ./...
 	$(call fmtcheck, .)
-
-get-deps:
-	@echo "+ Downloading dependencies"
-	@go get -d -t ./...
 
 test:
 	@echo "+ Testing package"

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -21,7 +21,6 @@ type iniTestValue struct {
 type iniSetTest struct {
 	name          string
 	values        []iniTestValue
-	wantErr       bool
 	initialText   string
 	expectedText  string
 	createIniFile bool
@@ -31,9 +30,7 @@ type iniSetTest struct {
 type iniGetTest struct {
 	name string
 	iniTestValue
-	wantErr       bool
 	initialText   string
-	expectedText  string
 	createIniFile bool
 	expectedErr   interface{}
 }
@@ -41,7 +38,6 @@ type iniGetTest struct {
 type iniDelTest struct {
 	name          string
 	values        []iniTestValue
-	wantErr       bool
 	initialText   string
 	expectedText  string
 	createIniFile bool

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,19 @@
 module github.com/bitnami/ini-file
 
-go 1.16
+go 1.18
 
 require (
 	github.com/bitnami/gonit v0.2.0
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ini/ini v1.62.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/juamedgod/cliassert v0.0.0-20180320011200-425256f2bb0b
+	github.com/stretchr/testify v1.2.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
-	github.com/stretchr/testify v1.2.2
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ type Options struct {
 var globalOpts = &Options{}
 
 var (
-	version   = "1.4.0"
+	version   = "1.4.2"
 	buildDate = ""
 	commit    = ""
 )


### PR DESCRIPTION
Updates Go dependency to 1.18, which also involves getting rid of many `go get`, replacing `golint` with `staticcheck` and fixing some linter warnings.

Signed-off-by: Marcos Bjoerkelund <marcos@bitnami.com>