### PR TITLE
Use ubuntu-latest runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   # This workflow contains a single job called "build"
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Build and Test
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -57,7 +57,7 @@ jobs:
   release:
     needs: [ 'build-and-test' ]
     if: github.repository == 'bitnami/render-template' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e


### PR DESCRIPTION
According to [this blogpost](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), `ubuntu-20.04` will be deprecated. We should upgrade them to `ubuntu-latest`.

No issues are expected.