### PR TITLE
Update Go version to 1.24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
-          go-version: '^1.22.4' # The Go version to download (if necessary) and use.
+          go-version: '^1.24.4' # The Go version to download (if necessary) and use.
       - name: Install Build Dependencies
         run: make get-build-deps
       - name: Download required modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker run --rm -it -v /tmp:/tmp bitnami/ini-file del -k "title" -s "My book" /tmp/my.ini
 #
 
-FROM golang:1.22-bullseye as build
+FROM golang:1.24-bookworm as build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git make upx \
@@ -20,7 +20,7 @@ RUN make
 
 RUN upx --ultra-brute out/ini-file
 
-FROM bitnami/minideb:bullseye
+FROM bitnami/minideb:bookworm
 
 COPY --from=build /go/src/app/out/ini-file /usr/local/bin/
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitnami/ini-file
 
-go 1.22
+go 1.24
 
 require (
 	github.com/bitnami/gonit v0.2.0

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ type Options struct {
 var globalOpts = &Options{}
 
 var (
-	version   = "1.4.7"
+	version   = "1.4.8"
 	buildDate = ""
 	commit    = ""
 )


### PR DESCRIPTION
### Description of the change

Bump Go version to 1.24.

### Benefits

Keep the project updated.

### Possible drawbacks

None

### Applicable issues


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
